### PR TITLE
Update event node status on cron.

### DIFF
--- a/eventbrite_events.module
+++ b/eventbrite_events.module
@@ -109,8 +109,12 @@ function eventbrite_events_cron() {
 
   $event_nodes =  \Drupal\node\Entity\Node::loadMultiple($event_nids);
 
-  // Get the event ID and status and run the sync_attendees service.
   foreach ($event_nodes as $event) {
+    // Update event status.
+    $status_service = \Drupal::service('eventbrite_events.status_handler');
+    $status_service->update($event);
+
+    // Get the event ID and status and run the sync_attendees service.
     $event_id = $event->get('eventbrite_event_id')->value;
     $event_status = $event->get('eventbrite_event_status')->value;
     $sync_service = \Drupal::service('eventbrite_events.sync_attendees');

--- a/src/StatusHandler.php
+++ b/src/StatusHandler.php
@@ -3,6 +3,7 @@
 namespace Drupal\eventbrite_events;
 
 use Drupal\eventbrite_events\Api;
+use Drupal\node\Entity\Node;
 
 /**
  * Class StatusHandler.
@@ -37,6 +38,21 @@ class StatusHandler {
 
     // Return Eventbrite's status code.
     return $result['status'];
+  }
+
+  /**
+   * Update an Event Node.
+   *
+   * @param \Drupal\node\Entity\Node $event
+   */
+  public function update(Node $event) {
+    // Call the API to check the event status
+    $eventbrite_event_id = $event->get('eventbrite_event_id')->value;
+    $status = $this->check($eventbrite_event_id);
+
+    // Set the status and save the node
+    $event->set('eventbrite_event_status', $status);
+    $event->save();
   }
 
 }


### PR DESCRIPTION
- Creates an `update()` method on the `StatusHandler` class to update Eventbrite Event nodes.
- Updates Eventbrite Event nodes' status field on cron.